### PR TITLE
Add deprecated warning when using .dark?

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rqrcode_core (0.1.0)
+    rqrcode_core (0.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -19,4 +19,4 @@ DEPENDENCIES
   rqrcode_core!
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/lib/rqrcode_core/qrcode/qr_code.rb
+++ b/lib/rqrcode_core/qrcode/qr_code.rb
@@ -233,6 +233,9 @@ module RQRCodeCore
       end
       @modules[row][col]
     end
+    alias_method :dark?, :checked?
+    extend Gem::Deprecate
+    deprecate :dark?, :checked?, 2020, 1
 
     # This is a public method that returns the QR Code you have
     # generated as a string. It will not be able to be read

--- a/lib/rqrcode_core/version.rb
+++ b/lib/rqrcode_core/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RQRCodeCore
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
This is to aid people who missed the warning in the release notes or haven't changed their code yet. I've aliased `dark?` and will remove it next year.