### PR TITLE
Bump version for Ruby 3 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rqrcode_core (0.1.1)
+    rqrcode_core (0.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -13,10 +13,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.0)
+  bundler (>= 2.0)
   minitest (~> 5.0)
   rake (~> 13.0)
   rqrcode_core!
 
 BUNDLED WITH
-   2.0.2
+   2.2.3

--- a/lib/rqrcode_core/version.rb
+++ b/lib/rqrcode_core/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RQRCodeCore
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/rqrcode_core.gemspec
+++ b/rqrcode_core.gemspec
@@ -26,7 +26,7 @@ EOF
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 2.3'
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
Github CI doesn't seem to have a Ruby 3.0 build to test against, but spec green locally.