### PR TITLE
Alternative ZFRS to improve memory allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add option to use ENV `RQRCODE_CORE_ARCH_BITS` to overide the bits value (32 or 64) used during the encoding process.
+  This has been shown to greatly reduce the memory usage but I can't prove it doesn't break anything for all people.
+  Use at your own risk.
+
 ## [1.2.0] - 2021-08-26
 
 - Added Multi Mode Support which allows for multi-segment encoding. Thanks to [@ssayer](https://github.com/ssayer)

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ $ rake standard # check
 $ rake standard:fix # fix
 ```
 
+## Experimental
+
+On 64 bit systems when generating lots of QR Codes the lib will consume more memory than on a 32 bit systems during the internal "right shift zero fill" steps (this is expected). In tests though, it's shown that by forcing the lib to think you're on a 32 systems greatly reduces the memory footprint. This could of course have undesired consequences too! but if you're happy to try, you can use the `RQRCODE_CORE_ARCH_BITS` ENV to make this change. e.g `RQRCODE_CORE_ARCH_BITS=32`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/whomwah/rqrcode_core.

--- a/lib/rqrcode_core/qrcode/qr_util.rb
+++ b/lib/rqrcode_core/qrcode/qr_util.rb
@@ -61,6 +61,14 @@ module RQRCodeCore
       QRMODE[:mode_kanji] => [8, 10, 12]
     }.freeze
 
+    # This value is used during the right shift zero fill step. It is
+    # auto set to 32 or 64 depending on the arch of your system running.
+    # 64 consumes a LOT more memory. In tests it's shown changing it to 32
+    # on 64 bit systems greatly reduces the memory footprint. You can use
+    # RQRCODE_CORE_ARCH_BITS to make this change but beware it may also
+    # have unintended consequences so use at your own risk.
+    ARCH_BITS = ENV.fetch("RQRCODE_CORE_ARCH_BITS", nil)&.to_i || 1.size * 8
+
     def self.max_size
       PATTERN_POSITION_TABLE.count
     end
@@ -74,8 +82,8 @@ module RQRCodeCore
     end
 
     def self.rszf(num, count)
-      # zero fill right shift
-      (num >> count) & ((2**((num.size * 8) - count)) - 1)
+      # right shift zero fill
+      (num >> count) & ((1 << (ARCH_BITS - count)) - 1)
     end
 
     def self.get_bch_version(data)


### PR DESCRIPTION
I'm no expert on bitwise optimization, and am trying to investigate and address https://github.com/whomwah/rqrcode_core/issues/27.

After a bit of research on `right shift zero fill` managed to change it and get some improvements. At least I think I am getting improvements as I don't have much experience with memory profiling either.

~Ultimately I think `num.size` was very slow and was being used to determine 32 or 64 bit system.~ 
UPDATE: This is not the issue. See https://github.com/whomwah/rqrcode_core/pull/28#discussion_r695577713

I've just hardcoded 32 for now which may have implications but the test suite doesn't show it. Changing to 64 seems to work too ! so I'd love to know more.

```ruby
def self.rszf(num, count)
  # right shift zero fill
  (num >> count) & ((1 << (32 - count)) - 1)
end
```

BEFORE:

`{:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_util.rb", :count=>3699640}`

```
vscode ➜ /workspaces/rqrcode_core (master ✗) $ ./bin/console
irb(main):001:0> require 'memory_profiler'; MemoryProfiler.report { RQRCodeCore::QRCode.new(("a" * 200)) }.allocated_memory_by_file
=> 
[{:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_util.rb", :count=>3699640},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_polynomial.rb", :count=>598240},
 {:data=>"<internal:kernel>", :count=>452144},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_code.rb", :count=>26576},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_alphanumeric.rb", :count=>13760},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_numeric.rb", :count=>12721},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_bit_buffer.rb", :count=>11280},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_rs_block.rb", :count=>1232},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_segment.rb", :count=>832},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_math.rb", :count=>384},
 {:data=>"(irb)", :count=>240}]
irb(main):002:0> exit
```

AFTER:

```
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_util.rb", :count=>112240},
```

```
vscode ➜ /workspaces/rqrcode_core (master ✗) $ ./bin/console
irb(main):001:0> require 'memory_profiler'; MemoryProfiler.report { RQRCodeCore::QRCode.new(("a" * 200)) }.allocated_memory_by_file
=> 
[{:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_polynomial.rb", :count=>598240},
 {:data=>"<internal:kernel>", :count=>452144},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_util.rb", :count=>112240},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_code.rb", :count=>26576},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_alphanumeric.rb", :count=>13760},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_numeric.rb", :count=>12721},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_bit_buffer.rb", :count=>11280},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_rs_block.rb", :count=>1232},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_segment.rb", :count=>832},
 {:data=>"/workspaces/rqrcode_core/lib/rqrcode_core/qrcode/qr_math.rb", :count=>384},
 {:data=>"(irb)", :count=>240}]
irb(main):002:0> 
```