### PR TITLE
Dependency upgrades

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7, '3.0', 3.1]
+        ruby: ['2.6', '2.7', '3.0', '3.1']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,35 +7,39 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    minitest (5.14.4)
-    parallel (1.21.0)
-    parser (3.1.0.0)
+    json (2.6.3)
+    language_server-protocol (3.17.0.2)
+    minitest (5.16.3)
+    parallel (1.22.1)
+    parser (3.1.3.0)
       ast (~> 2.4.1)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.2.0)
+    regexp_parser (2.6.1)
     rexml (3.2.5)
-    rubocop (1.25.0)
+    rubocop (1.40.0)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.1.2.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.15.1, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.23.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.1)
-      parser (>= 3.0.1.1)
-    rubocop-performance (1.13.2)
+    rubocop-ast (1.24.0)
+      parser (>= 3.1.1.0)
+    rubocop-performance (1.15.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
-    standard (1.7.0)
-      rubocop (= 1.25.0)
-      rubocop-performance (= 1.13.2)
-    standardrb (1.0.0)
+    standard (1.20.0)
+      language_server-protocol (~> 3.17.0.2)
+      rubocop (= 1.40.0)
+      rubocop-performance (= 1.15.1)
+    standardrb (1.0.1)
       standard
-    unicode-display_width (2.1.0)
+    unicode-display_width (2.3.0)
 
 PLATFORMS
   ruby
@@ -48,4 +52,4 @@ DEPENDENCIES
   standardrb (~> 1.0)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/lib/rqrcode_core/qrcode/qr_bit_buffer.rb
+++ b/lib/rqrcode_core/qrcode/qr_bit_buffer.rb
@@ -15,12 +15,12 @@ module RQRCodeCore
 
     def get(index)
       buf_index = (index / 8).floor
-      ((QRUtil.rszf(@buffer[buf_index], 7 - index % 8)) & 1) == 1
+      (QRUtil.rszf(@buffer[buf_index], 7 - index % 8) & 1) == 1
     end
 
     def put(num, length)
       (0...length).each do |i|
-        put_bit(((QRUtil.rszf(num, length - i - 1)) & 1) == 1)
+        put_bit((QRUtil.rszf(num, length - i - 1) & 1) == 1)
       end
     end
 

--- a/lib/rqrcode_core/qrcode/qr_code.rb
+++ b/lib/rqrcode_core/qrcode/qr_code.rb
@@ -288,7 +288,7 @@ module RQRCodeCore
       min_lost_point = 0
       pattern = 0
 
-      (0...8).each do |i|
+      8.times do |i|
         make_impl(true, i)
         lost_point = QRUtil.get_lost_points(modules)
 
@@ -326,7 +326,7 @@ module RQRCodeCore
     def place_version_info(test) # :nodoc:
       bits = QRUtil.get_bch_version(@version)
 
-      (0...18).each do |i|
+      18.times do |i|
         mod = (!test && ((bits >> i) & 1) == 1)
         @modules[(i / 3).floor][ i % 3 + @module_count - 8 - 3 ] = mod
         @modules[i % 3 + @module_count - 8 - 3][ (i / 3).floor ] = mod
@@ -375,7 +375,7 @@ module RQRCodeCore
         col -= 1 if col <= 6
 
         loop do
-          (0...2).each do |c|
+          2.times do |c|
             if @modules[row][col - c].nil?
               dark = false
               if byte_index < data.size && !data[byte_index].nil?
@@ -473,7 +473,7 @@ module RQRCodeCore
           ecdata_block = Array.new(rs_poly.get_length - 1)
           ecdata_block.size.times do |i|
             mod_index = i + mod_poly.get_length - ecdata_block.size
-            ecdata_block[i] = mod_index >= 0 ? mod_poly.get(mod_index) : 0
+            ecdata_block[i] = (mod_index >= 0) ? mod_poly.get(mod_index) : 0
           end
           ecdata[r] = ecdata_block
         end

--- a/lib/rqrcode_core/qrcode/qr_math.rb
+++ b/lib/rqrcode_core/qrcode/qr_math.rb
@@ -6,7 +6,7 @@ module RQRCodeCore
       exp_table = Array.new(256)
       log_table = Array.new(256)
 
-      (0...8).each do |i|
+      8.times do |i|
         exp_table[i] = 1 << i
       end
 
@@ -17,7 +17,7 @@ module RQRCodeCore
           ^ exp_table[i - 8]
       end
 
-      (0...255).each do |i|
+      255.times do |i|
         log_table[exp_table[i]] = i
       end
 

--- a/lib/rqrcode_core/qrcode/qr_segment.rb
+++ b/lib/rqrcode_core/qrcode/qr_segment.rb
@@ -36,7 +36,7 @@ module RQRCodeCore
         [1, 8, 0]
       end
 
-      (data_length / chunk_size) * bit_length + ((data_length % chunk_size) == 0 ? 0 : extra)
+      (data_length / chunk_size) * bit_length + (((data_length % chunk_size) == 0) ? 0 : extra)
     end
 
     def writer

--- a/rqrcode_core.gemspec
+++ b/rqrcode_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3"
+  spec.required_ruby_version = ">= 2.6"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
* run `bundle update`
* upgrade to `actions/checkout@v3`
* re-running take to use new `standard` rules
* bump minimum version to `2.6`