### PR TITLE
chore: Updating dependencies

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: whomwah
+buy_me_a_coffee: duncanrobertson

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,41 +7,50 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    json (2.6.3)
-    language_server-protocol (3.17.0.2)
-    minitest (5.16.3)
-    parallel (1.22.1)
-    parser (3.1.3.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    minitest (5.25.1)
+    parallel (1.26.3)
+    parser (3.3.5.0)
       ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.6.1)
-    rexml (3.2.5)
-    rubocop (1.40.0)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rubocop (1.66.1)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.2.1)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.23.0, < 2.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.24.0)
-      parser (>= 3.1.1.0)
-    rubocop-performance (1.15.1)
-      rubocop (>= 1.7.0, < 2.0)
-      rubocop-ast (>= 0.4.0)
-    ruby-progressbar (1.11.0)
-    standard (1.20.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.32.3)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.22.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    standard (1.41.0)
       language_server-protocol (~> 3.17.0.2)
-      rubocop (= 1.40.0)
-      rubocop-performance (= 1.15.1)
-    standardrb (1.0.1)
-      standard
-    unicode-display_width (2.3.0)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.66.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.5)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.5.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.22.0)
+    unicode-display_width (2.6.0)
 
 PLATFORMS
+  aarch64-linux
   ruby
 
 DEPENDENCIES
@@ -49,7 +58,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   rake (~> 13.0)
   rqrcode_core!
-  standardrb (~> 1.0)
+  standard (~> 1.41)
 
 BUNDLED WITH
-   2.3.26
+   2.5.16

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features:
 * It is an encoding library. You can't decode QR Codes with it.
 * The interface is simple and assumes you just want to encode a string into a QR Code, but also allows for encoding multiple segments.
 * QR Code is trademarked by Denso Wave inc.
+* Minimum Ruby version is `>= 3.0.0`
 
 `rqrcode_core` is the basis of the popular `rqrcode` gem [https://github.com/whomwah/rqrcode]. This gem allows you to generate different renderings of your QR Code, including `png`, `svg` and `ansi`.
 

--- a/lib/rqrcode_core/qrcode/qr_code.rb
+++ b/lib/rqrcode_core/qrcode/qr_code.rb
@@ -274,8 +274,8 @@ module RQRCodeCore
         (-1..7).each do |c|
           next unless (col + c).between?(0, @module_count - 1)
 
-          is_vert_line = (r.between?(0, 6) && (c == 0 || c == 6))
-          is_horiz_line = (c.between?(0, 6) && (r == 0 || r == 6))
+          is_vert_line = r.between?(0, 6) && (c == 0 || c == 6)
+          is_horiz_line = c.between?(0, 6) && (r == 0 || r == 6)
           is_square = r.between?(2, 4) && c.between?(2, 4)
 
           is_part_of_probe = is_vert_line || is_horiz_line || is_square
@@ -315,7 +315,7 @@ module RQRCodeCore
 
           (-2..2).each do |r|
             (-2..2).each do |c|
-              is_part_of_pattern = (r.abs == 2 || c.abs == 2 || (r == 0 && c == 0))
+              is_part_of_pattern = r.abs == 2 || c.abs == 2 || (r == 0 && c == 0)
               @modules[row + r][col + c] = is_part_of_pattern
             end
           end
@@ -327,7 +327,7 @@ module RQRCodeCore
       bits = QRUtil.get_bch_version(@version)
 
       18.times do |i|
-        mod = (!test && ((bits >> i) & 1) == 1)
+        mod = !test && ((bits >> i) & 1) == 1
         @modules[(i / 3).floor][ i % 3 + @module_count - 8 - 3 ] = mod
         @modules[i % 3 + @module_count - 8 - 3][ (i / 3).floor ] = mod
       end
@@ -338,7 +338,7 @@ module RQRCodeCore
       bits = QRUtil.get_bch_format_info(data)
 
       QRFORMATINFOLENGTH.times do |i|
-        mod = (!test && ((bits >> i) & 1) == 1)
+        mod = !test && ((bits >> i) & 1) == 1
 
         # vertical
         row = if i < 6

--- a/rqrcode_core.gemspec
+++ b/rqrcode_core.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 3.0.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "standardrb", "~> 1.0"
+  spec.add_development_dependency "standard", "~> 1.41"
 end


### PR DESCRIPTION
Changes that don't yet require a release:

* Any new release will require `Ruby >= 3.0.0`. This is not because the library won't support lesser versions but I think its healthy to move the requirement forward to enable use of the latest syntax and features.
* With the update other dependencies have been upgraded and new formatting applied