### PR TITLE
Feat/fixes april 2025

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,11 +3,11 @@ name: rqrcode_core
 on:
   push:
     branches:
-    - master
-    - release/*
+      - master
+      - release/*
   pull_request:
     branches:
-    - master
+      - master
   workflow_dispatch:
 
 jobs:
@@ -16,15 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['3.0', '3.1', '3.2', '3.3']
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run Tests
-      run: bundle exec rake test
-    - name: StandardRB Check
-      run: bundle exec standardrb --format progress
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run Tests
+        run: bundle exec rake test
+      - name: StandardRB Check
+        run: bundle exec standardrb --format progress

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 Features:
 
-* `rqrcode_core` is a Ruby only library. It requires no 3rd party libraries. Just Ruby!
-* It is an encoding library. You can't decode QR Codes with it.
-* The interface is simple and assumes you just want to encode a string into a QR Code, but also allows for encoding multiple segments.
-* QR Code is trademarked by Denso Wave inc.
-* Minimum Ruby version is `>= 3.0.0`
+- `rqrcode_core` is a Ruby only library. It requires no 3rd party libraries. Just Ruby!
+- It is an encoding library. You can't decode QR Codes with it.
+- The interface is simple and assumes you just want to encode a string into a QR Code, but also allows for encoding multiple segments.
+- QR Code is trademarked by Denso Wave inc.
+- Minimum Ruby version is `>= 3.0.0`
 
 `rqrcode_core` is the basis of the popular `rqrcode` gem [https://github.com/whomwah/rqrcode]. This gem allows you to generate different renderings of your QR Code, including `png`, `svg` and `ansi`.
 
@@ -97,7 +97,6 @@ mode - the mode of the QR Code (defaults to alphanumeric or byte_8bit, depending
   * :number
   * :alphanumeric
   * :byte_8bit
-  * :kanji
 ```
 
 #### Example

--- a/lib/rqrcode_core/qrcode/qr_code.rb
+++ b/lib/rqrcode_core/qrcode/qr_code.rb
@@ -2,9 +2,9 @@
 
 module RQRCodeCore
   QRMODE = {
-    mode_number: 1 << 0,
-    mode_alpha_numk: 1 << 1,
-    mode_8bit_byte: 1 << 2
+    mode_number: 1 << 0,      # 1 (binary: 0001)
+    mode_alpha_numk: 1 << 1,  # 2 (binary: 0010)
+    mode_8bit_byte: 1 << 2   # 4 (binary: 0100)
   }.freeze
 
   QRMODE_NAME = {
@@ -97,7 +97,6 @@ module RQRCodeCore
     #      * :number
     #      * :alphanumeric
     #      * :byte_8bit
-    #      * :kanji
     #
     #   qr = RQRCodeCore::QRCode.new('hello world', size: 1, level: :m, mode: :alphanumeric)
     #   segment_qr = QRCodeCore::QRCode.new({ data: 'foo', mode: :byte_8bit })

--- a/lib/rqrcode_core/qrcode/qr_segment.rb
+++ b/lib/rqrcode_core/qrcode/qr_segment.rb
@@ -8,7 +8,7 @@ module RQRCodeCore
       @data = data
       @mode = QRMODE_NAME.dig(mode&.to_sym)
 
-      # If mode is not explicitely found choose mode according to data type
+      # If mode is not explicitly found choose mode according to data type
       @mode ||= if RQRCodeCore::QRNumeric.valid_data?(@data)
         QRMODE_NAME[:number]
       elsif QRAlphanumeric.valid_data?(@data)

--- a/lib/rqrcode_core/qrcode/qr_util.rb
+++ b/lib/rqrcode_core/qrcode/qr_util.rb
@@ -57,8 +57,7 @@ module RQRCodeCore
     BITS_FOR_MODE = {
       QRMODE[:mode_number] => [10, 12, 14],
       QRMODE[:mode_alpha_numk] => [9, 11, 13],
-      QRMODE[:mode_8bit_byte] => [8, 16, 16],
-      QRMODE[:mode_kanji] => [8, 10, 12]
+      QRMODE[:mode_8bit_byte] => [8, 16, 16]
     }.freeze
 
     # This value is used during the right shift zero fill step. It is

--- a/lib/rqrcode_core/qrcode/qr_util.rb
+++ b/lib/rqrcode_core/qrcode/qr_util.rb
@@ -254,7 +254,8 @@ module RQRCodeCore
         sum + col.count(true)
       end
 
-      ratio = dark_count / (modules.size * modules.size)
+      # Convert to float to prevent integer division
+      ratio = dark_count.to_f / (modules.size * modules.size)
       ratio_delta = (100 * ratio - 50).abs / 5
 
       ratio_delta * DEMERIT_POINTS_4

--- a/rqrcode_core.gemspec
+++ b/rqrcode_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = "~> 3.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/test/rqrcode_core/qr_util_test.rb
+++ b/test/rqrcode_core/qr_util_test.rb
@@ -1,0 +1,108 @@
+require "test_helper"
+
+module RQRCodeCore
+  class QRUtilTest < Minitest::Test
+    def test_demerit_points_4_dark_ratio
+      # Test with all white modules (ratio = 0)
+      # Expected: (100 * 0 - 50).abs / 5 * 10 = 10 * 10 = 100
+      modules = Array.new(4) { Array.new(4, false) }
+      assert_equal 100, QRUtil.demerit_points_4_dark_ratio(modules)
+
+      # Test with all black modules (ratio = 1)
+      # Expected: (100 * 1 - 50).abs / 5 * 10 = 50 / 5 * 10 = 10 * 10 = 100
+      modules = Array.new(4) { Array.new(4, true) }
+      assert_equal 100, QRUtil.demerit_points_4_dark_ratio(modules)
+
+      # Test with half black, half white modules (ratio = 0.5)
+      # Expected: (100 * 0.5 - 50).abs / 5 * 10 = 0 / 5 * 10 = 0
+      modules = [
+        [true, true, false, false],
+        [true, true, false, false],
+        [false, false, true, true],
+        [false, false, true, true]
+      ]
+      assert_equal 0, QRUtil.demerit_points_4_dark_ratio(modules)
+
+      # Test with 25% black modules (ratio = 0.25)
+      # Expected: (100 * 0.25 - 50).abs / 5 * 10 = 25 / 5 * 10 = 5 * 10 = 50
+      modules = [
+        [true, false, false, false],
+        [false, true, false, false],
+        [false, false, true, false],
+        [false, false, false, true]
+      ]
+      assert_equal 50, QRUtil.demerit_points_4_dark_ratio(modules)
+
+      # Test with 75% black modules (ratio = 0.75)
+      # Expected: (100 * 0.75 - 50).abs / 5 * 10 = 25 / 5 * 10 = 5 * 10 = 50
+      modules = [
+        [true, true, true, true],
+        [true, true, true, false],
+        [true, true, false, true],
+        [true, false, false, true]
+      ]
+      assert_equal 50, QRUtil.demerit_points_4_dark_ratio(modules)
+
+      # Test with different sized modules (3x3)
+      # 3 black out of 9 = 1/3 ratio = 0.33...
+      # Expected: (100 * (3/9) - 50).abs / 5 * 10 ≈ 16.67 * 10 = 166.7
+      modules = [
+        [true, false, false],
+        [false, true, false],
+        [false, false, true]
+      ]
+      expected = ((100 * (3.0 / 9) - 50).abs / 5) * 10
+      assert_in_delta expected, QRUtil.demerit_points_4_dark_ratio(modules), 0.01
+    end
+
+    def test_demerit_points_4_dark_ratio_edge_cases
+      # Test with empty modules
+      # This shouldn't happen in real QR codes, but let's be safe
+      modules = []
+      assert QRUtil.demerit_points_4_dark_ratio(modules).nan?
+
+      # Test with 1x1 module
+      # All white
+      modules = [[false]]
+      assert_equal 100, QRUtil.demerit_points_4_dark_ratio(modules)
+
+      # All black
+      modules = [[true]]
+      assert_equal 100, QRUtil.demerit_points_4_dark_ratio(modules)
+    end
+
+    def test_demerit_points_4_dark_ratio_formula
+      # Test the formula directly for a specific case
+      # For a 5x5 module with 13 dark cells:
+      # ratio = 13/25 = 0.52
+      # ratio_delta = (100 * 0.52 - 50).abs / 5 = 2/5 = 0.4
+      # demerit points = 0.4 * 10 = 4
+      modules = [
+        [true, true, true, false, false],
+        [true, true, true, false, false],
+        [true, true, true, false, true],
+        [true, true, false, false, false],
+        [true, false, false, false, false]
+      ]
+
+      # Count dark modules
+      dark_count = modules.flatten.count(true)
+      assert_equal 13, dark_count
+
+      # Calculate ratio
+      ratio = dark_count.to_f / (5 * 5)
+      assert_in_delta 0.52, ratio, 0.001
+
+      # Calculate ratio_delta
+      ratio_delta = (100 * ratio - 50).abs / 5
+      assert_in_delta 0.4, ratio_delta, 0.001
+
+      # Calculate demerit points
+      demerit_points = ratio_delta * 10
+      assert_in_delta 4, demerit_points, 0.001
+
+      # Check that our method gives the same result
+      assert_in_delta 4, QRUtil.demerit_points_4_dark_ratio(modules), 0.001
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces several updates, including the addition of Ruby 3.4 to the test matrix, removal of support for the `kanji` QR mode, improvements to code comments and documentation, and the addition of comprehensive tests for the `demerit_points_4_dark_ratio` method. Below is a summary of the most important changes grouped by theme.

### Ruby Version Updates
* Added Ruby 3.4 to the test matrix in the GitHub Actions workflow (`.github/workflows/ruby.yml`).
* Updated the required Ruby version in the gemspec to `~> 3.0` to allow compatibility with patch releases (`rqrcode_core.gemspec`).

### QR Code Mode Changes
* Removed support for the `kanji` QR mode from the codebase, including the `QRMODE` hash, `BITS_FOR_MODE` mapping, and relevant documentation in `README.md` and comments. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L100) [[2]](diffhunk://#diff-3a5fa6d5024c3e7f48ea072c0a8866acf1fe988cfb55996daec45df66e9c4065L5-R7) [[3]](diffhunk://#diff-3a5fa6d5024c3e7f48ea072c0a8866acf1fe988cfb55996daec45df66e9c4065L100) [[4]](diffhunk://#diff-f9d29f02c75c9882c941d27083e847ca901716560a54e48fa497457c8535556bL60-R60)

### Documentation and Comment Improvements
* Fixed a typo in a comment in the `QRSegment` initialization method (`qr_segment.rb`).
* Enhanced inline comments in the `QRMODE` hash to clarify the binary representation of QR modes (`qr_code.rb`).

### Testing Enhancements
* Added a comprehensive suite of tests for the `demerit_points_4_dark_ratio` method, covering various scenarios, edge cases, and formula validation (`qr_util_test.rb`).

These changes improve compatibility, maintainability, and test coverage for the `rqrcode_core` library.